### PR TITLE
Removed incorrect flush

### DIFF
--- a/python/dlog_python/__init__.py
+++ b/python/dlog_python/__init__.py
@@ -10,8 +10,5 @@ class DlogLogger(StreamHandler):
     def emit(self, record):
         self.instance.log(record.levelno, self.format(record))
 
-    def flush(self) -> None:
-        self.instance.clean_up()
-
     def __del__(self):
         self.instance.clean_up()


### PR DESCRIPTION
Removed an incorrect `clean_up` call inside of flush. This would have resulted in an exception.