### PR TITLE
Fixed premature shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,10 @@
 [workspace]
-
 members = [
     "native",
     "python",
     "nodejs/native"
+]
+
+default-members = [
+    "native"
 ]

--- a/native/Cargo.toml
+++ b/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "native"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Lennart Voorgang <lennart@voorgang.dev>"]
 edition = "2018"
 

--- a/nodejs/native/Cargo.toml
+++ b/nodejs/native/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dlog-nodejs"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Lennart Voorgang <lennart@voorgang.dev>"]
 license = "MIT"
 build = "build.rs"

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dlog-nodejs",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "Pure Node.JS bindings for dlog",
   "main": "lib/index.js",
   "author": "lennartvrg",

--- a/python/Cargo.toml
+++ b/python/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "python"
-version = "0.1.4"
+version = "0.1.5"
 authors = ["Lennart Voorgang <lennart@voorgang.dev>"]
 edition = "2018"
 

--- a/python/dlog_python/__init__.py
+++ b/python/dlog_python/__init__.py
@@ -1,11 +1,11 @@
-from logging import StreamHandler
-from .dlog_python import PythonLogger
+from logging import StreamHandler as _StreamHandler
+from .dlog_python import PythonLogger as _PythonLogger
 
 
-class DlogLogger(StreamHandler):
+class DlogLogger(_StreamHandler):
     def __init__(self, api_key):
-        StreamHandler.__init__(self)
-        self.instance = PythonLogger(api_key)
+        _StreamHandler.__init__(self)
+        self.instance = _PythonLogger(api_key)
 
     def emit(self, record):
         self.instance.log(record.levelno, self.format(record))

--- a/python/example/main.py
+++ b/python/example/main.py
@@ -1,19 +1,10 @@
 import logging
+import time
 from dlog_python import DlogLogger
 
 
-class Main:
-    def __init__(self):
-        self.logger = logging.getLogger('main')
-        self.logger.setLevel(logging.DEBUG)
-        self.logger.addHandler(DlogLogger("997a1c6f-4fff-4a7e-b399-74ac397a4fec"))
+logger = logging.getLogger('main')
+logger.setLevel(logging.DEBUG)
+logger.addHandler(DlogLogger("997a1c6f-4fff-4a7e-b399-74ac397a4fec"))
 
-    def run(self):
-        while True:
-            log = input("> ")
-            self.logger.info(log)
-
-
-if __name__ == "__main__":
-    main = Main()
-    main.run()
+logger.info("Test")

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "dlog_python"
-version = "0.1.4"
+version = "0.1.5"
 description = "Python adapter for the dlog loggin platform"
 license = "MIT"
 python = "^3.8"


### PR DESCRIPTION
Fixed the problem where in very small programs the runtime (JavaScript v8 / Python) would terminate before the
ingestion thread is started. This would result in log message being lost as the end-of-life `clean_up` would do nothing.